### PR TITLE
FIX: zero bug

### DIFF
--- a/js/calcLevelUp.js
+++ b/js/calcLevelUp.js
@@ -15,6 +15,9 @@ function calc_amount_mob() {
   mob_exp *= mob_penalty
 
   mob_exp = Math.round(parseInt(mob_exp) * (addition_exp * 0.01));
+  if(mob_exp == 0){
+    mob_exp = 1
+  }
 
   let cur_exp_amount = exp_table[cur_level] * (cur_exp_rate * 0.01); // 현재 경험치량
 


### PR DESCRIPTION
calc_amount_mob() 함수에서 mob_exp을 계산할 때, 특정 조건에서 0.n이 나오는 경우 0이 되는 것으로 추정됨.
그 경우 mob_exp를 1로 두어 Infinity가 뜨는 것을 방지함.

- 기존 테스트 코드
  - 현재 레벨: 200
  - 현재 경험치: 0
  - 몹 경험치: 1
  - 6분 마릿수: 1
  - 월드 구분: 일반

- 기존 결과
  - 마릿수: Infinity 마리
  - 레벨업 소요 시간: Infinity 시간

- 수정 후 결과
  - 마릿수: 2207026470 마리
  - 레벨업 소요 시간: 220702647.00 시간